### PR TITLE
Feat: Add media upload bucket for temporary artifacts for posts/users/collections

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -52,7 +52,7 @@ jobs:
           profile_picture_bucket_name                              = "dexbooru-prd-pfps"
           post_picture_bucket_name                                 = "dexbooru-prd-posts"
           post_collection_picture_bucket_name                      = "dexbooru-prd-collections"
-          upload_artifacts_bucket_name                        = "dexbooru-prd-upload-artifacts"
+          upload_artifacts_bucket_name                             = "dexbooru-prd-upload-artifacts"
           machine_learning_models_bucket_name                      = "dexbooru-prd-machine-learning-models"
           machine_learning_models_iam_user_name                    = "dexbooru-ml-models-iam-user"
           machine_learning_models_iam_policy_name                  = "dexbooru-ml-models-policy"

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -52,6 +52,7 @@ jobs:
           profile_picture_bucket_name                              = "dexbooru-prd-pfps"
           post_picture_bucket_name                                 = "dexbooru-prd-posts"
           post_collection_picture_bucket_name                      = "dexbooru-prd-collections"
+          upload_artifacts_bucket_name                        = "dexbooru-prd-upload-artifacts"
           machine_learning_models_bucket_name                      = "dexbooru-prd-machine-learning-models"
           machine_learning_models_iam_user_name                    = "dexbooru-ml-models-iam-user"
           machine_learning_models_iam_policy_name                  = "dexbooru-ml-models-policy"

--- a/.github/workflows/terraform-pr.yml
+++ b/.github/workflows/terraform-pr.yml
@@ -51,6 +51,7 @@ jobs:
           profile_picture_bucket_name                              = "dexbooru-prd-pfps"
           post_picture_bucket_name                                 = "dexbooru-prd-posts"
           post_collection_picture_bucket_name                      = "dexbooru-prd-collections"
+          upload_artifacts_bucket_name                        = "dexbooru-prd-upload-artifacts"
           machine_learning_models_bucket_name                      = "dexbooru-prd-machine-learning-models"
           machine_learning_models_iam_user_name                    = "dexbooru-ml-models-iam-user"
           machine_learning_models_iam_policy_name                  = "dexbooru-ml-models-policy"

--- a/.github/workflows/terraform-pr.yml
+++ b/.github/workflows/terraform-pr.yml
@@ -51,7 +51,7 @@ jobs:
           profile_picture_bucket_name                              = "dexbooru-prd-pfps"
           post_picture_bucket_name                                 = "dexbooru-prd-posts"
           post_collection_picture_bucket_name                      = "dexbooru-prd-collections"
-          upload_artifacts_bucket_name                        = "dexbooru-prd-upload-artifacts"
+          upload_artifacts_bucket_name                             = "dexbooru-prd-upload-artifacts"
           machine_learning_models_bucket_name                      = "dexbooru-prd-machine-learning-models"
           machine_learning_models_iam_user_name                    = "dexbooru-ml-models-iam-user"
           machine_learning_models_iam_policy_name                  = "dexbooru-ml-models-policy"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -23,7 +23,7 @@ module "build_s3_resources" {
   post_collection_picture_bucket_name        = var.post_collection_picture_bucket_name
   machine_learning_models_bucket_name        = var.machine_learning_models_bucket_name
   anime_faces_captcha_challenges_bucket_name = var.anime_faces_captcha_challenges_bucket_name
-  upload_artifacts_bucket_name          = var.upload_artifacts_bucket_name
+  upload_artifacts_bucket_name               = var.upload_artifacts_bucket_name
 }
 
 module "build_sqs_resources" {
@@ -41,7 +41,7 @@ module "build_iam_resources" {
   profile_picture_bucket_arn         = module.build_s3_resources.s3_buckets["profile_pictures"].arn
   post_picture_bucket_arn            = module.build_s3_resources.s3_buckets["post_pictures"].arn
   post_collection_picture_bucket_arn = module.build_s3_resources.s3_buckets["collection_pictures"].arn
-  upload_artifacts_bucket_arn   = module.build_s3_resources.s3_buckets["upload_artifacts"].arn
+  upload_artifacts_bucket_arn        = module.build_s3_resources.s3_buckets["upload_artifacts"].arn
 
   post_anime_series_queue_arn = module.build_sqs_resources.post_anime_classification_queue_arn
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -23,6 +23,7 @@ module "build_s3_resources" {
   post_collection_picture_bucket_name        = var.post_collection_picture_bucket_name
   machine_learning_models_bucket_name        = var.machine_learning_models_bucket_name
   anime_faces_captcha_challenges_bucket_name = var.anime_faces_captcha_challenges_bucket_name
+  upload_artifacts_bucket_name          = var.upload_artifacts_bucket_name
 }
 
 module "build_sqs_resources" {
@@ -40,6 +41,7 @@ module "build_iam_resources" {
   profile_picture_bucket_arn         = module.build_s3_resources.s3_buckets["profile_pictures"].arn
   post_picture_bucket_arn            = module.build_s3_resources.s3_buckets["post_pictures"].arn
   post_collection_picture_bucket_arn = module.build_s3_resources.s3_buckets["collection_pictures"].arn
+  upload_artifacts_bucket_arn   = module.build_s3_resources.s3_buckets["upload_artifacts"].arn
 
   post_anime_series_queue_arn = module.build_sqs_resources.post_anime_classification_queue_arn
 

--- a/infrastructure/modules/cloudfront/main.tf
+++ b/infrastructure/modules/cloudfront/main.tf
@@ -33,6 +33,14 @@ locals {
   }
 
   default_origin_id = length(keys(local.origins)) > 0 ? keys(local.origins)[0] : ""
+
+  # Only CDN-facing buckets get OAI read policies (exclude private buckets like
+  # machine_learning_models and upload_artifacts).
+  cdn_bucket_keys = toset([for key in values(local.key_map) : key])
+  cdn_s3_origins = {
+    for key, bucket in var.s3_origins : key => bucket
+    if contains(local.cdn_bucket_keys, key)
+  }
 }
 
 resource "aws_cloudfront_origin_access_identity" "oai" {
@@ -40,7 +48,7 @@ resource "aws_cloudfront_origin_access_identity" "oai" {
 }
 
 data "aws_iam_policy_document" "s3_read" {
-  for_each = var.s3_origins
+  for_each = local.cdn_s3_origins
   statement {
     actions   = ["s3:GetObject"]
     resources = ["${each.value.arn}/*"]
@@ -52,7 +60,7 @@ data "aws_iam_policy_document" "s3_read" {
 }
 
 resource "aws_s3_bucket_policy" "allow_cdn_read" {
-  for_each = var.s3_origins
+  for_each = local.cdn_s3_origins
   bucket   = each.value.id
   policy   = data.aws_iam_policy_document.s3_read[each.key].json
 }

--- a/infrastructure/modules/iam/main.tf
+++ b/infrastructure/modules/iam/main.tf
@@ -30,7 +30,9 @@ data "aws_iam_policy_document" "dexbooru_user_webapp_document" {
 
     resources = [
       var.profile_picture_bucket_arn,
-      var.post_picture_bucket_arn
+      var.post_picture_bucket_arn,
+      var.post_collection_picture_bucket_arn,
+      var.upload_artifacts_bucket_arn
     ]
   }
 
@@ -47,7 +49,8 @@ data "aws_iam_policy_document" "dexbooru_user_webapp_document" {
     resources = [
       "${var.profile_picture_bucket_arn}/*",
       "${var.post_picture_bucket_arn}/*",
-      "${var.post_collection_picture_bucket_arn}/*"
+      "${var.post_collection_picture_bucket_arn}/*",
+      "${var.upload_artifacts_bucket_arn}/*"
     ]
   }
 

--- a/infrastructure/modules/iam/variables.tf
+++ b/infrastructure/modules/iam/variables.tf
@@ -23,6 +23,11 @@ variable "post_collection_picture_bucket_arn" {
   description = "The ARN of the S3 bucket used for storing post collection pictures."
 }
 
+variable "upload_artifacts_bucket_arn" {
+  type        = string
+  description = "The ARN of the S3 bucket used for temporary raw post upload artifacts."
+}
+
 variable "post_anime_series_queue_arn" {
   type        = string
   description = "The ARN of the SQS queue used for post anime series classification."

--- a/infrastructure/modules/s3/main.tf
+++ b/infrastructure/modules/s3/main.tf
@@ -5,6 +5,7 @@ locals {
     collection_pictures            = var.post_collection_picture_bucket_name
     machine_learning_models        = var.machine_learning_models_bucket_name
     anime_faces_captcha_challenges = var.anime_faces_captcha_challenges_bucket_name
+    upload_artifacts               = var.upload_artifacts_bucket_name
   }
 }
 
@@ -16,5 +17,23 @@ resource "aws_s3_bucket" "buckets" {
 
   tags = {
     filepath = "${path.module}/main.tf"
+  }
+}
+
+# Temporary raw uploads should not linger if a worker/request crashes mid-pipeline.
+resource "aws_s3_bucket_lifecycle_configuration" "upload_artifacts" {
+  bucket = aws_s3_bucket.buckets["upload_artifacts"].id
+
+  rule {
+    id     = "expire-stale-upload-artifacts"
+    status = "Enabled"
+
+    filter {
+      prefix = "uploads/"
+    }
+
+    expiration {
+      days = 1
+    }
   }
 }

--- a/infrastructure/modules/s3/variables.tf
+++ b/infrastructure/modules/s3/variables.tf
@@ -23,3 +23,8 @@ variable "anime_faces_captcha_challenges_bucket_name" {
   type        = string
   description = "The name of the S3 bucket used to store anime faces captcha challenges."
 }
+
+variable "upload_artifacts_bucket_name" {
+  type        = string
+  description = "The name of the S3 bucket used for temporary raw post upload artifacts before image processing."
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -30,6 +30,11 @@ variable "anime_faces_captcha_challenges_bucket_name" {
   description = "The S3 bucket name for storing anime faces captcha challenges"
 }
 
+variable "upload_artifacts_bucket_name" {
+  type        = string
+  description = "The S3 bucket name for temporary raw post upload artifacts before image processing"
+}
+
 variable "anime_faces_captcha_challenges_iam_user_name" {
   type        = string
   description = "The IAM user name for the anime faces captcha challenges"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added temporary storage for raw post upload artifacts before image processing.
  * Upload artifacts are automatically deleted after one day to reduce unnecessary storage.
  * Updated access permissions to support uploading and processing these artifacts.

* **Bug Fixes**
  * Refined CDN access rules so only CDN-facing storage buckets receive read permissions, improving access isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->